### PR TITLE
fix: prevent absolute file_path from overriding base save directory

### DIFF
--- a/backend/app/api/wx.py
+++ b/backend/app/api/wx.py
@@ -32,7 +32,7 @@ async def upload_zip(
         file_path: Optional[str] = Form(...),
         sys_session_id: Optional[int] = Form(...),
         wx_id: Optional[str] = Form(...)):
-    file_path = file_path.replace("\\", '/')
+    file_path = file_path.replace("\\", "/").lstrip("/")
     logger.info("文件路径：" + str(file_path))
     wx_dir = get_wx_dir_directly(sys_session_id, wx_id)
     save_path = os.path.join(wx_dir, file_path)


### PR DESCRIPTION
## 🐛 问题描述

`/upload-single/` 接口中，当 `file_path` 为绝对路径（例如以 `/` 开头）时，`os.path.join(wx_dir, file_path)` 会直接忽略前面的 `wx_dir`，导致文件被错误保存到服务器根目录（如 `/FileStorage/...`），而不是微信用户对应的 session 目录中。

## 🔁 复现步骤

调用上传接口 `/upload-single/`，传入如下 `file_path`：

```plaintext
/FileStorage/File/2025-04/xxx.pdf
```

查看日志，可见保存路径为：

```plaintext
保存路径：/FileStorage/File/2025-04/xxx.pdf
```

而不是期望中的：

```plaintext
保存路径：/app/data/sessions/{session_id}/wxid_{wx_id}/FileStorage/File/2025-04/xxx.pdf
```

## ✅ 解决方案

在拼接路径前，使用 `file_path.lstrip("/")` 将绝对路径转换为相对路径，确保其被正确拼接到 `wx_dir` 下：

```python
file_path = file_path.replace("\\", "/").lstrip("/")
save_path = os.path.join(wx_dir, file_path)
```

这样可以确保无论传入的路径是否带 `/`，文件都会保存在正确的微信用户目录中。

相关日志见附件图片
![image](https://github.com/user-attachments/assets/16bb6bab-eb89-4ff4-8864-f0533b9adfd1)

